### PR TITLE
added onthespot to arch aur repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,17 @@ Make sure [python3](https://www.python.org/downloads) and [Git](https://git-scm.
   
 ## 1.2. Using prebuilt binaries
 ### On Linux
+#### Arch Linux
+`onthespot` is available for arch linux and arch linux based distributions in arch user repository (aur) as [onthespot-git](https://aur.archlinux.org/packages/onthespot-git).
+
+You can install `onthespot` using your favourite aur helper.
+
+For eg: using yay
+```
+yay -Sy onthespot-git
+```
+
+#### Other Distributions
 Download Latest 'onthespot_linux' from the release section and execute with
  ```
  chmod +x onthespot_linux


### PR DESCRIPTION
I created and added onthespot package-build for arch linux.
Anyone using arch or arch based distribution can now install `opthespot` from aur using a single command [Tried and Tested].

I'll try to add the package to other distributions (debian, fedora and others) as well.