### PR TITLE
Add metadata to the lrc lyrics files

### DIFF
--- a/src/onthespot/utils/spotify.py
+++ b/src/onthespot/utils/spotify.py
@@ -32,7 +32,7 @@ def get_playlist_data(session, playlist_id):
     return sanitize_data(resp['name']), sanitize_data(resp['owner']['display_name']), sanitize_data(resp['description']), resp['external_urls']['spotify']
 
 
-def get_track_lyrics(session, track_id, forced_synced):
+def get_track_lyrics(session, track_id, metadata, forced_synced):
     lyrics = []
     try:
         params = 'format=json&market=from_token'
@@ -43,10 +43,25 @@ def get_track_lyrics(session, track_id, forced_synced):
             params=params,
             headers=headers
         )
+
+        for key in metadata.keys():
+            value = metadata[key]
+            if key == 'artists':
+                artist = conv_artist_format(value)
+            elif key in ['name', 'track_title', 'tracktitle']:
+                tracktitle = value
+            elif key in ['album_name', 'album']:
+                album = value
+
         if lyrics_json_req.status_code == 200:
             lyrics_json = lyrics_json_req.json()
-            lyrics.append(f'[au:{lyrics_json["provider"]}]')
-            lyrics.append('[by:casualsnek-onTheSpot]')
+            lyrics.append(f'[ti:{tracktitle}]')
+            # lyrics.append(f'[au:Songwriter]')
+            lyrics.append(f'[ar:{artist}]')
+            lyrics.append(f'[al:{album}]')
+            lyrics.append(f'[by:{lyrics_json["provider"]}]')
+            lyrics.append('[ve:0.5]')
+            lyrics.append('[re:casualsnek-onTheSpot]')
             if lyrics_json['kind'].lower() == 'text':
                 # It's un synced lyrics, if not forcing synced lyrics return it
                 if not forced_synced:

--- a/src/onthespot/worker/downloader.py
+++ b/src/onthespot/worker/downloader.py
@@ -181,7 +181,7 @@ class DownloadWorker(QObject):
                         self.logger.info(f'Fetching lyrics for track id: {trk_track_id_str}, '
                                          f'{config.get("only_synced_lyrics")}')
                         try:
-                            lyrics = get_track_lyrics(session, trk_track_id_str, config.get('only_synced_lyrics'))
+                            lyrics = get_track_lyrics(session, trk_track_id_str, song_info, config.get('only_synced_lyrics'))
                             if lyrics:
                                 self.logger.info(f'Found lyrics for: {trk_track_id_str}, writing...')
                                 if config.get('use_lrc_file', 1):


### PR DESCRIPTION
[According to wikipedia](https://en.wikipedia.org/wiki/LRC_(file_format)) the `lrc` files supports some ID tags, so I though it's a good idea to added to the lyrics files here.

I tweked a little the order of the tags from the wikipedia example to match [the format used on gnome-subtitles](https://gitlab.gnome.org/GNOME/gnome-subtitles/-/blob/master/src/SubLib/IO/SubtitleFormats/SubtitleFormatKaraokeLyricsLRC.cs), (why? i'ts the one I'm using to edit some files), feel free to change it if necessary.
Also note that I changed the place of the previous `au`, `by` tags, what do you think? Program could be stylized as: `OnTheSpot by CasuAlSnek` like in the About tab

The added tags are: 
- Title
- Artist
- Album
- Maker (provider, the one who create the lrc file)
- Version (of the program)
- Program (used to create the file)

Notes:
* The version is hard coded 
* Also from wikipedia it seems to support the `length` tag, ex: [length: 2:23]
* The Author (songwriter) tag is still missing. _On Spotify if you right-click on a song and then click on `Show credits` the songwriter(s) appear. It looks like is not in the lyrics json file [here](https://github.com/lwd-temp/spotify-json-lyrics/blob/main/lyrics.json)_. I think having this tag on the `lrc` file is very important because is not present on the audio file.