### PR TITLE
Update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,24 @@ If you have an idea for an improvement or feature, create a issue or join the di
 
 # 1. Installing/launching application:
 ## 1.1. Launch without installing - from source
-Make sure [python3](https://www.python.org/downloads) and [Git](https://git-scm.com/downloads) are installed on your system, if you are on windows you also need to install Microsoft C++ build tools from [HERE](https://visualstudio.microsoft.com/visual-cpp-build-tools/) and restart your computer before starting build process.
-  - Download or Clone the repo ```git clone https://github.com/casualsnek/onthespot```
-  - Navigate to the onthespot directory ```cd onthespot```
-  - Install the dependencies with ```pip install -r requirements.txt```
-  - Navigate to source directory ```cd src```
-  - Launch the application with ```python3 -m onthespot```
- 
- *Windows users should also follow these extra steps before running:* ```python3 onthespot.py```
- ```
- pip install winsdk
- ```
-  
-## 1.2. Using portable prebuilt binaries
+
+Make sure [ffmpeg](https://ffmpeg.org/), [python3](https://www.python.org/downloads) and [Git](https://git-scm.com/downloads) are installed and available on your `$PATH`. If you are on windows, you also need to install the [Microsoft C++ build tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) and restart your computer before starting the build process.
+  1. Download or Clone the repo ```git clone https://github.com/casualsnek/onthespot```
+  1. Navigate to the onthespot directory ```cd onthespot```
+  1. Install the package ```pip install -r requirements.txt```
+  1. Navigate to source directory ```cd src```
+  1. Launch the application with ```python3 -m onthespot```
+
+## 1.2. Launch with installing - from source
+
+The requirements are the same as "Launching without installing" above.
+
+1. Download or Clone the repo ```git clone https://github.com/casualsnek/onthespot```
+1. Navigate to the onthespot directory ```cd onthespot```
+1. Install the package ```pip install .```
+1. Launch the application with ```onthespot_gui```
+
+## 1.3. Using portable prebuilt binaries
 ### On Linux
 #### Arch Linux
 `onthespot` is available for arch linux and arch linux based distributions in arch user repository (aur) as [onthespot-git](https://aur.archlinux.org/packages/onthespot-git).
@@ -54,7 +59,6 @@ If you are using binaries that does not bundle ffmpeg and downloads gets stuck a
 - Open CMD as administrator and run the command: ```setx /m PATH "C:\ffmpeg\bin;%PATH%"```
 
 Now the application should work as expected.
-
 
 # 2. Building/packaging manually
 Building or packaging on any OS requires Git, Python3 and Pip installed. Make sure you have them installed !
@@ -88,6 +92,23 @@ build_winC1.bat
 build_winC2.bat
 ```
 After the command completes, you should have a 'dist' directory in repository root containing built 'onthespot_win.exe' binary.
+
+### 2.1.3. On MacOS
+
+**NOTE :** This only builds an app for the specific processor architecture you are on. It does not build a universal binary
+
+Open terminal emulator and run the following command to clone the repository and build.
+```bash
+git clone https://github.com/casualsnek/onthespot
+cd onthespot
+```
+
+If you want builds with ffmpeg embedded download ffmpeg binaries for your os from [Here](https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full.7z).
+Create a new directory named 'ffbin_mac' in repository root directory. Copy three files 'ffmpeg', 'ffprobe', 'ffplay' from the downloaded archive to the newly created 'ffbin_mac' directory then run:
+```bash
+./build_mac.sh
+```
+After the command completes, you should have a 'dist' directory in repository root containing the 'onthespot_mac.app' binary.
 
 ## 2.2.  Building wheel for installing with pip
 You can also build onthespot as wheel and install it as python module via pip in your system. It provides better integration with system, like using your system's Qt style and themes as well as you can use provided icon and .desktop file for better integration under linux systems.

--- a/build_mac.sh
+++ b/build_mac.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+clean_build_dirs () {
+    [ -d ./__pycache__ ] && rm -rf __pycache__
+    [ -d ./build ] && rm -rf ./build
+    [ -d ./venv ] && rm -rf ./venv
+    [ -f ./onthespot_mac.spec ] && rm ./onthespot_mac.spec
+    [ -f ./onthespot_mac_ffm.spec ] && rm ./onthespot_mac_ffm.spec
+    [ -d ./dist/onthespot_mac ] && rm -rf ./dist/onthespot_mac
+}
+
+
+echo "========= OnTheSpot MacOS Build Script ==========="
+echo " => Cleaning up !"
+[ -d ./dist/onthespot_mac.app ] && rm -rf ./dist/onthespot_mac.app
+[ -d ./dist/onthespot_mac_ffm.app ] && rm -rf ./dist/onthespot_mac_ffm.app
+clean_build_dirs
+
+echo " => Creating virtual env."
+python3 -m venv venv
+
+echo " => Switching to virtual env."
+source ./venv/bin/activate
+
+echo " => Installing 'pyinstaller' via pip..."
+pip install pyinstaller
+
+echo " => Installing dependencies to venv with pip..."
+pip install -r requirements.txt
+
+if [ -f "ffbin_mac/ffmpeg" ]; then
+    echo " => Found 'ffbin_mac' directory and ffmpeg binary.. Using ffmpeg binary append mode "
+    pyinstaller --windowed \
+                --add-data="src/onthespot/gui/qtui/*.ui:onthespot/gui/qtui" \
+                --add-data="src/onthespot/resources/*.png:onthespot/resources" \
+                --add-binary="ffbin_nix/*:onthespot/bin/ffmpeg" \
+                --paths="src/onthespot" \
+                --name="onthespot_mac_ffm" \
+                --icon="src/onthespot/resources/icon.png" \
+                src/portable.py
+else
+    echo " => Building to use ffmpeg binary from system... "
+    pyinstaller --windowed \
+                --add-data="src/onthespot/gui/qtui/*.ui:onthespot/gui/qtui" \
+                --add-data="src/onthespot/resources/*.png:onthespot/resources" \
+                --paths="src/onthespot" \
+                --name="onthespot_mac" \
+                --icon="src/onthespot/resources/icon.png" \
+                src/portable.py
+fi
+echo " => Setting executable permissions.. "
+[ -f ./dist/onthespot_mac ] && chmod +x ./dist/onthespot_mac &>./build_nix.log
+[ -f ./dist/onthespot_mac_ffm ] && chmod +x ./dist/onthespot_mac_ffm &>./build_nix.log
+
+echo " => Cleaning .. "
+clean_build_dirs
+
+echo " => Done "

--- a/build_mac.sh
+++ b/build_mac.sh
@@ -33,7 +33,7 @@ if [ -f "ffbin_mac/ffmpeg" ]; then
     pyinstaller --windowed \
                 --add-data="src/onthespot/gui/qtui/*.ui:onthespot/gui/qtui" \
                 --add-data="src/onthespot/resources/*.png:onthespot/resources" \
-                --add-binary="ffbin_nix/*:onthespot/bin/ffmpeg" \
+                --add-binary="ffbin_mac/*:onthespot/bin/ffmpeg" \
                 --paths="src/onthespot" \
                 --name="onthespot_mac_ffm" \
                 --icon="src/onthespot/resources/icon.png" \

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ show-in-file-manager==1.1.4
 urllib3==2.0.2
 websocket-client==1.5.1
 zeroconf==0.62.0
+winsdk;platform_system=='Windows'

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,32 +15,7 @@ package_dir=
     =src
 python_requires = >= 3.0
 packages = find:
-install_requires =
-    async-timeout==4.0.2
-    certifi==2022.12.7
-    charset-normalizer==3.1.0
-    defusedxml==0.7.1
-    idna==3.4
-    ifaddr==0.2.0
-    librespot==0.0.8
-    music-tag==0.4.3
-    mutagen==1.46.0
-    packaging==23.1
-    Pillow==9.5.0
-    protobuf==3.20.1
-    pycryptodomex==3.17
-    PyOgg==0.6.14a1
-    PyQt5==5.15.9
-    PyQt5-Qt5==5.15.2
-    PyQt5-sip==12.12.1
-    PyQt5-stubs==5.15.6.0
-    pyxdg==0.28
-    requests==2.28.2
-    show-in-file-manager==1.1.4
-    urllib3==1.26.15
-    websocket-client==1.5.1
-    zeroconf==0.55.0
-    winsdk;platform_system=='Windows'
+install_requires = file:requirements.txt
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
* Make setup.cfg use requirements.txt for install_requires
* List winsdk in the requirements.txt to make setup easier
* Create a build script for MacOS
* Update README instructions

The setup.cfg requirements were out of date with the requirements.txt.
This meant that if you built a binary using the setup.cfg, it would have
an outdated version of librespot and be unable to login. Given that
setuptools and pip can both use properly formatted PEP-508 syntax and
onthespot is not using any pip-specific syntax, this can be unified into
the requirements.txt file for ease.