### PR TITLE
Fix empty genre

### DIFF
--- a/src/onthespot/worker/downloader.py
+++ b/src/onthespot/worker/downloader.py
@@ -55,7 +55,7 @@ class DownloadWorker(QObject):
                     artist=_artist,
                     rel_year=song_info['release_year'],
                     album=song_info['album_name'],
-                    genre=song_info['genre'][0] if len(song_info['genre']) > 0 else '',
+                    genre=song_info['genre'][0] if len(song_info['genre']) > 0 else 'unknown',
                     label=song_info['label'],
                     trackcount=song_info['total_tracks'],
                     playlist_name=playlist_name,


### PR DESCRIPTION
When we use genre in the path to the album directory name formatter it can't be empty
![image](https://github.com/casualsnek/onthespot/assets/76652885/f74d657d-0ed7-4c91-8279-368aee637687)

