### PR TITLE
Mirror Spotify Playback / Fetch Metadata via API

### DIFF
--- a/src/onthespot/gui/qtui/main.ui
+++ b/src/onthespot/gui/qtui/main.ui
@@ -879,7 +879,7 @@
               <item>
                <widget class="QCheckBox" name="inp_enable_spot_watch">
                 <property name="text">
-                 <string>Enable desktop app play to download</string>
+                 <string>Mirror Spotify Playback</string>
                 </property>
                </widget>
               </item>


### PR DESCRIPTION
The following PR pulls the track url through currently-playing api if the desktop app is not detected or fails. Adds support for spotify mobile apps, web browsers, and any other devices that use the official api.

The PR also removes a redundant regex under linux.

Test build available here: https://gofile.io/d/Tw3xp3